### PR TITLE
Add username length validation

### DIFF
--- a/src/mya.c
+++ b/src/mya.c
@@ -34,12 +34,17 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state) {
 	case 'p': arguments->mode = PLAN_MODE; break;
 	case 'a': arguments->mode = ALL_MODE; break;
 	case ARGP_KEY_ARG:
-		  if (state->arg_num >= 1) argp_usage(state);
-		  arguments->args[state->arg_num] = arg;
-		  break;
+		if (state->arg_num >= 1) argp_usage(state);
+		size_t arg_len = strlen(arg);
+		if (arg_len < 2 || arg_len > 16) {
+			printf("Username must be between 2 and 16 characters in length\n");
+			exit(argp_err_exit_status);
+		}
+		arguments->args[state->arg_num] = arg;
+		break;
 	case ARGP_KEY_END:
-		  if (state->arg_num < 1) argp_usage(state);
-		  break;
+		if (state->arg_num < 1) argp_usage(state);
+		break;
 	default: return ARGP_ERR_UNKNOWN;
 	}
 	return 0;


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #5

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Added a validation check on the first arg to be between 2 and 16 characters in length by using the `strlen` function.

If the validation fails, the program prints out the following message `Username must be between 2 and 16 characters in length` and then immediately exits.