### PR TITLE
Username char validation

### DIFF
--- a/src/mya.c
+++ b/src/mya.c
@@ -4,6 +4,7 @@
 #include <argp.h>
 #include <curl/curl.h>
 #include <json-c/json.h>
+#include <regex.h>
 
 const char *argp_program_version = "mya v0.1.0";
 const char *argp_program_bug_address = "<jmakhack@protonmail.com>";
@@ -40,6 +41,19 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state) {
 			printf("Username must be between 2 and 16 characters in length\n");
 			exit(argp_err_exit_status);
 		}
+		regex_t regex;
+		char *pattern = "^[a-zA-Z0-9_-]+$";
+		size_t nmatch = 1;
+		regmatch_t pmatch[1];
+		if (regcomp(&regex, pattern, REG_EXTENDED)) {
+			fprintf(stderr, "Failed to compile username validation regex\n");
+			exit(argp_err_exit_status);
+		}
+		if (regexec(&regex, arg, nmatch, pmatch, 0)) {
+			printf("Please enter a valid username (letters, numbers, underscores and dashes only)\n");
+			exit(argp_err_exit_status);
+		}
+		regfree(&regex);
 		arguments->args[state->arg_num] = arg;
 		break;
 	case ARGP_KEY_END:

--- a/src/mya.c
+++ b/src/mya.c
@@ -34,12 +34,17 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state) {
 	case 'p': arguments->mode = PLAN_MODE; break;
 	case 'a': arguments->mode = ALL_MODE; break;
 	case ARGP_KEY_ARG:
-		  if (state->arg_num >= 1) argp_usage(state);
-		  arguments->args[state->arg_num] = arg;
-		  break;
+		if (state->arg_num >= 1) argp_usage(state);
+		size_t arg_len = strlen(arg);
+		if (arg_len < 2 || arg_len > 16) {
+			printf("Username must be between 2 and 16 characters in length\n");
+			exit(argp_err_exit_status);
+		}
+		arguments->args[state->arg_num] = arg;
+		break;
 	case ARGP_KEY_END:
-		  if (state->arg_num < 1) argp_usage(state);
-		  break;
+		if (state->arg_num < 1) argp_usage(state);
+		break;
 	default: return ARGP_ERR_UNKNOWN;
 	}
 	return 0;

--- a/src/mya.c
+++ b/src/mya.c
@@ -37,7 +37,10 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state) {
 	case ARGP_KEY_ARG:
 		if (state->arg_num >= 1) argp_usage(state);
 		
-		size_t arg_len = strlen(arg);
+		char username[18];
+		strncpy(username, arg, sizeof(username)-1);
+		username[17] = '\0';
+		size_t arg_len = strlen(username);
 		regex_t regex;
 		char *pattern = "^[a-zA-Z0-9_-]+$";
 		size_t nmatch = 1;


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #4

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Included `regex.h` and use the `regcomp` and `regexec` functions to do a regex based validation check on the user inputted username.

If the validation fails, the program displays the following message: `Please enter a valid username (letters, numbers, underscores and dashes only)` and then immediately exits. Including certain characters (such as &) will throw a shell-based error since they are special characters that are parsed separately before being passed into the program.