### PR TITLE
workflow added for auto assign author

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,14 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.0


### PR DESCRIPTION
## Associated Issue
Closes #42 

## Implemented Solution
- Added a GitHub action in the workflows directory that will automatically add the GitHub user as assignee to the pull request that they have created.

- Took reference from the link provided in the issue.
