### PR TITLE
Add missing file pattern to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@jmakhack
+* @jmakhack


### PR DESCRIPTION
## Associated Issue
closes #46 

<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->

## Implemented Solution
The CODEOWNERS file was missing a filepath before the github username. You can verify by opening any file in this repo in the github ui. You should see a lock icon with hover text telling you the codeowner for that file

![Screen Shot 2022-10-06 at 8 55 58 AM](https://user-images.githubusercontent.com/20004072/194346894-dd63f757-ef45-4d7d-a56d-810ef6c7d905.png)

Here is an example from a different repo where the CODEOWNERS file is correct:

![Screen Shot 2022-10-06 at 8 57 37 AM](https://user-images.githubusercontent.com/20004072/194347173-befee4a1-dc9d-43c1-880c-b89804b76445.png)

Adding a file pattern to CODEOWNERS should fix this

See also the [github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) on codeowners and the syntax for this file
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
