### PR TITLE
Fixes issue #51: Changed error message in case client ID is not provided

### DIFF
--- a/src/mya.c
+++ b/src/mya.c
@@ -394,7 +394,10 @@ int main (int argc, char *argv[]) {
 
 		/* error when anime list is not found due to invalid user */
 		if (!json_object_object_get_ex(json, "data", &anime_list)) {
-			fprintf(stderr, "User not found\n");
+			if (strcmp(CLIENT_ID, "YOUR TOKEN HERE")==0)
+				fprintf(stderr, "Client ID has not been provided\n");
+			else
+				fprintf(stderr, "User not found\n");
 			exit(EXIT_FAILURE);
 		}
 

--- a/src/mya.c
+++ b/src/mya.c
@@ -394,7 +394,7 @@ int main (int argc, char *argv[]) {
 
 		/* error when anime list is not found due to invalid user */
 		if (!json_object_object_get_ex(json, "data", &anime_list)) {
-			if (strcmp(CLIENT_ID, "YOUR TOKEN HERE")==0)
+			if (strcmp(CLIENT_ID, "YOUR TOKEN HERE") == 0)
 				fprintf(stderr, "Client ID has not been provided\n");
 			else
 				fprintf(stderr, "User not found\n");


### PR DESCRIPTION

## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #51 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
I've added a new condition in case of error when anime list is not found due to invalid user to check if it's because the client ID has not been added and updated the error message for this scenario.
