### PR TITLE
Option to block NSFW results

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Simple command line tool for fetching user anime data from MyAnimeList.
   -h, --onhold               Fetch a user's on hold anime
   -p, --plantowatch          Fetch a user's plan to watch anime
   -w, --watching             Fetch a user's currently watching anime
+  -s, --sfw                  Fetch only SFW anime
   -?, --help                 Give this help list
       --usage                Give a short usage message
   -V, --version              Print program version

--- a/src/mya.c
+++ b/src/mya.c
@@ -260,6 +260,7 @@ void generate_endpoint (char *endpoint, size_t mode) {
  * uri: string to store the uri
  * username: user to fetch the data of
  * endpoint: endpoint to fetch the data from
+ * allow_nsfw: allow/block nsfw results to be fetched
  */
 void generate_anime_api_uri (char *uri, char *username, char *endpoint, int allow_nsfw) {
 	strcpy(uri, "https://api.myanimelist.net/v2/users/");

--- a/src/mya.c
+++ b/src/mya.c
@@ -269,7 +269,7 @@ void generate_anime_api_uri (char *uri, char *username, char *endpoint, int allo
 	strcat(uri, endpoint);
 
 	/* enable/disable NSFW */
-	if(allow_nsfw == 1)
+	if (allow_nsfw == 1)
 		strcat(uri, "&nsfw=true");
 	else
 		strcat(uri, "&nsfw=false");


### PR DESCRIPTION
Closes #56 

Added the option `-s`, which limits the anime fetched from the API to only SFW (Safe For Work).
This option can be used with the other options for fetching anime.