### PR TITLE
fix: make precedence of operators within expressions explicit

### DIFF
--- a/src/mya.c
+++ b/src/mya.c
@@ -75,7 +75,7 @@ void validate_username (char *username) {
 	regmatch_t pmatch[1];
 
 	/* check if username is acceptable length */	
-	if (username_len < MIN_USERNAME_LENGTH || username_len > MAX_USERNAME_LENGTH) {
+	if ((username_len < MIN_USERNAME_LENGTH) || (username_len > MAX_USERNAME_LENGTH)) {
 		fprintf(stderr, "Username must be between %d and %d characters in length\n", MIN_USERNAME_LENGTH, MAX_USERNAME_LENGTH);
 		exit(argp_err_exit_status);
 	}


### PR DESCRIPTION
## Associated Issue
Closes #75 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Added brackets to make the precedence of operators explicit.

`if (username_len < MIN_USERNAME_LENGTH || username_len > MAX_USERNAME_LENGTH)`
to
`if ((username_len < MIN_USERNAME_LENGTH) || (username_len > MAX_USERNAME_LENGTH)) `