### PR TITLE
Fix str commands buffer size arguments

### DIFF
--- a/src/mya.c
+++ b/src/mya.c
@@ -374,7 +374,6 @@ void print_anime_list (struct json_object *anime_list, size_t page, char *list_n
 		struct json_object *anime = json_object_array_get_idx(anime_list, i);
 		struct json_object *anime_node = json_object_object_get(anime, "node");
 		struct json_object *anime_title = json_object_object_get(anime_node, "title");
-		char *color = NULL;
 
 		/* Printing in alternate colors for better readability */
 		const char* color = (i % 2 == 1) ? ANSI_CODE_YELLOW : ANSI_CODE_CYAN;

--- a/src/mya.c
+++ b/src/mya.c
@@ -376,10 +376,10 @@ void print_anime_list (struct json_object *anime_list, size_t page, char *list_n
 		struct json_object *anime_title = json_object_object_get(anime_node, "title");
 
 		/* Printing in alternate colors for better readability */
-		const char* color = (i % 2 == 1) ? ANSI_CODE_YELLOW : ANSI_CODE_CYAN;
+		const char* color = (((int)i % 2) == 1) ? ANSI_CODE_YELLOW : ANSI_CODE_CYAN;
 
 		/* print each anime title in a numbered list format */
-		printf("%s%zu. %s%s\n", color, (i + 1) + ((size_t)PAGE_SIZE * (page - 1)), json_object_get_string(anime_title), ANSI_CODE_RESET);
+		printf("%s%zu. %s%s\n", color, ((int)i + 1) + (PAGE_SIZE * ((int)page - 1)), json_object_get_string(anime_title), ANSI_CODE_RESET);
 	}
 }
 

--- a/src/mya.c
+++ b/src/mya.c
@@ -379,7 +379,8 @@ void print_anime_list (struct json_object *anime_list, size_t page, char *list_n
 		const char* color = (((int)i % 2) == 1) ? ANSI_CODE_YELLOW : ANSI_CODE_CYAN;
 
 		/* print each anime title in a numbered list format */
-		printf("%s%zu. %s%s\n", color, ((int)i + 1) + (PAGE_SIZE * ((int)page - 1)), json_object_get_string(anime_title), ANSI_CODE_RESET);
+		const int list_num = ((int)i + 1) + (PAGE_SIZE * ((int)page - 1));
+		printf("%s%d. %s%s\n", color, list_num, json_object_get_string(anime_title), ANSI_CODE_RESET);
 	}
 }
 

--- a/src/mya.c
+++ b/src/mya.c
@@ -23,6 +23,11 @@
 #define OPT_ALL          'a'
 #define OPT_SFW          's'
 
+/* constants for ANSI color codes */
+#define ANSI_CODE_CYAN   "\033[0;36m"
+#define ANSI_CODE_YELLOW "\033[1;33m"
+#define ANSI_CODE_RESET  "\033[0m"
+
 /* initialize argp vars */
 const char *argp_program_version     = "mya v0.1.0";
 const char *argp_program_bug_address = "<jmakhack@protonmail.com>";
@@ -371,9 +376,15 @@ void print_anime_list (struct json_object *anime_list, size_t page, char *list_n
 		struct json_object *anime = json_object_array_get_idx(anime_list, i);
 		struct json_object *anime_node = json_object_object_get(anime, "node");
 		struct json_object *anime_title = json_object_object_get(anime_node, "title");
+		char *color = NULL;
 
+		/* Printing in alternate colors for better readability */
+		if (i % 2)
+			color = ANSI_CODE_YELLOW;
+		else
+			color = ANSI_CODE_CYAN;
 		/* print each anime title in a numbered list format */
-		printf("%zu. %s\n", (i+1)+(PAGE_SIZE*(page-1)), json_object_get_string(anime_title));
+		printf("%s%zu. %s%s\n", color, (i+1)+(PAGE_SIZE*(page-1)), json_object_get_string(anime_title), ANSI_CODE_RESET);
 	}
 }
 

--- a/src/mya.c
+++ b/src/mya.c
@@ -23,9 +23,9 @@
 #define OPT_SFW          's'
 
 /* constants for ANSI color codes */
-#define ANSI_CODE_CYAN   "\033[0;36m"
-#define ANSI_CODE_YELLOW "\033[1;33m"
-#define ANSI_CODE_RESET  "\033[0m"
+#define ANSI_CODE_CYAN   "\033" "[0;36m"
+#define ANSI_CODE_YELLOW "\033" "[1;33m"
+#define ANSI_CODE_RESET  "\033" "[0m"
 
 /* initialize argp vars */
 const char *argp_program_version     = "mya v0.1.0";
@@ -374,15 +374,12 @@ void print_anime_list (struct json_object *anime_list, size_t page, char *list_n
 		struct json_object *anime = json_object_array_get_idx(anime_list, i);
 		struct json_object *anime_node = json_object_object_get(anime, "node");
 		struct json_object *anime_title = json_object_object_get(anime_node, "title");
-		char *color = NULL;
 
 		/* Printing in alternate colors for better readability */
-		if (i % 2)
-			color = ANSI_CODE_YELLOW;
-		else
-			color = ANSI_CODE_CYAN;
+		const char* color = (i % 2 == 1) ? ANSI_CODE_YELLOW : ANSI_CODE_CYAN;
+
 		/* print each anime title in a numbered list format */
-		printf("%s%zu. %s%s\n", color, (i+1)+(PAGE_SIZE*(page-1)), json_object_get_string(anime_title), ANSI_CODE_RESET);
+		printf("%s%zu. %s%s\n", color, (i + 1) + ((size_t)PAGE_SIZE * (page - 1)), json_object_get_string(anime_title), ANSI_CODE_RESET);
 	}
 }
 


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes N/A

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Fixing the `strlcpy` and `strlcat` commands to use destination buffer size for the third argument as specified in their documentation reference.
